### PR TITLE
Feat: expose zmanim more

### DIFF
--- a/zmanim/zmanim.go
+++ b/zmanim/zmanim.go
@@ -41,7 +41,7 @@ type Zmanim struct {
 	Year     int        // Gregorian year
 	Month    time.Month // Gregorian month
 	Day      int        // Gregorian day
-	loc      *time.Location
+	TimeZone *time.Location
 }
 
 // New makes an instance used for calculating various halachic times during this day.
@@ -56,14 +56,14 @@ func New(location *Location, date time.Time) Zmanim {
 	if err != nil {
 		panic(err)
 	}
-	return Zmanim{Location: location, Year: year, Month: month, Day: day, loc: loc}
+	return Zmanim{Location: location, Year: year, Month: month, Day: day, TimeZone: loc}
 }
 
 func (z *Zmanim) inLoc(dt time.Time) time.Time {
 	if dt.IsZero() {
 		return dt
 	}
-	return dt.In(z.loc)
+	return dt.In(z.TimeZone)
 }
 
 // Sunset ("shkiah") calculates when the sun will set on the given day
@@ -123,14 +123,14 @@ func (z *Zmanim) Hour() float64 {
 // GregEve returns the time of the previous day's sunset,
 // which is the beginning of the Hebrew calendar day.
 func (z *Zmanim) GregEve() time.Time {
-	prev := time.Date(z.Year, z.Month, z.Day-1, 0, 0, 0, 0, z.loc)
+	prev := time.Date(z.Year, z.Month, z.Day-1, 0, 0, 0, 0, z.TimeZone)
 	year, month, day := prev.Date()
 	zman := Zmanim{
 		Location: z.Location,
 		Year:     year,
 		Month:    month,
 		Day:      day,
-		loc:      z.loc,
+		TimeZone: z.TimeZone,
 	}
 	return zman.Sunset()
 }
@@ -148,7 +148,7 @@ func (z *Zmanim) NightHour() float64 {
 func (z *Zmanim) HourOffset(hours float64) time.Time {
 	rise := z.Sunrise()
 	seconds := rise.Unix() + int64(z.Hour()*hours)
-	return time.Unix(seconds, 0).In(z.loc)
+	return time.Unix(seconds, 0).In(z.TimeZone)
 }
 
 // NightHourOffset returns yesterday's sunset plus
@@ -156,7 +156,7 @@ func (z *Zmanim) HourOffset(hours float64) time.Time {
 func (z *Zmanim) NightHourOffset(hours float64) time.Time {
 	set := z.GregEve()
 	seconds := set.Unix() + int64(z.NightHour()*hours)
-	return time.Unix(seconds, 0).In(z.loc)
+	return time.Unix(seconds, 0).In(z.TimeZone)
 }
 
 // Midday – Chatzot; Sunrise plus 6 halachic hours
@@ -169,7 +169,7 @@ func (z *Zmanim) Chatzot() time.Time {
 func (z *Zmanim) ChatzotNight() time.Time {
 	rise := z.Sunrise()
 	seconds := rise.Unix() - int64(z.NightHour()*6.0)
-	return time.Unix(seconds, 0).In(z.loc)
+	return time.Unix(seconds, 0).In(z.TimeZone)
 }
 
 // Dawn – Alot haShachar; Sun is 16.1° below the horizon in the morning
@@ -203,7 +203,7 @@ func (z *Zmanim) sofZmanMGA(hours float64) time.Time {
 	alot72sec := alot72.Unix()
 	temporalHour := float64(tzeit72.Unix()-alot72sec) / 12.0 // sec in hour
 	seconds := alot72sec + int64(hours*temporalHour)
-	return time.Unix(seconds, 0).In(z.loc)
+	return time.Unix(seconds, 0).In(z.TimeZone)
 }
 
 // Latest Shema (MGA); Sunrise plus 3 halachic hours, according to Magen Avraham
@@ -268,7 +268,7 @@ func (z *Zmanim) riseSetOffset(t time.Time, offset int, roundTime bool) time.Tim
 		}
 		sec = 0
 	}
-	return time.Date(year, month, day, hour, min+offset, sec, 0, z.loc)
+	return time.Date(year, month, day, hour, min+offset, sec, 0, z.TimeZone)
 }
 
 // Returns sunrise + offset minutes (either positive or negative).


### PR DESCRIPTION
When importing `hebcal-go/zmanim`, some useful functionality has been inaccessible because the identifiers were private. This PR exposes and documents useful zmanim bits so that other modules can access them.

For example, I am developing a small templating tool called [`hebcalfmt`](https://github.com/chaimleib/hebcalfmt). It calls into the `hebcal-go` package, but I've been having to do some repetition there to access `HourOffset` and `TimeAtAngle`, and the timezone of a `zmanim.Zmanim`.