### PR TITLE
fix(hebcal): skip non-existent year 0 when computing Gregorian end date

### DIFF
--- a/hebcal/hebcal.go
+++ b/hebcal/hebcal.go
@@ -325,7 +325,13 @@ func getStartAndEnd(opts *CalOptions) (int64, int64, error) {
 		if opts.NoJulian {
 			endAbs = greg.ProlepticToRD(year+numYears, time.January, 1)
 		} else {
-			endAbs = greg.ToRD(year+numYears, time.January, 1)
+			endYear := year + numYears
+			// historical Gregorian calendar has no year 0; 1 BC (-1) is
+			// followed directly by 1 AD (+1), so skip over 0
+			if year < 0 && endYear >= 0 {
+				endYear++
+			}
+			endAbs = greg.ToRD(endYear, time.January, 1)
 		}
 		return startAbs, endAbs - 1, nil
 	}

--- a/hebcal/hebcal_test.go
+++ b/hebcal/hebcal_test.go
@@ -521,6 +521,37 @@ func TestYear1(t *testing.T) {
 	assert.Equal(t, 79, len(events))
 }
 
+func TestYearMinus1(t *testing.T) {
+	opts := hebcal.CalOptions{
+		Year: -1,
+	}
+	events, err := hebcal.HebrewCalendar(&opts)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, events)
+	first := events[0].GetDate()
+	last := events[len(events)-1].GetDate()
+	fy, _, _ := first.Greg()
+	ly, _, _ := last.Greg()
+	assert.Equal(t, -1, fy)
+	assert.Equal(t, -1, ly)
+}
+
+func TestYearMinus1NumYears2(t *testing.T) {
+	opts := hebcal.CalOptions{
+		Year:     -1,
+		NumYears: 2,
+	}
+	events, err := hebcal.HebrewCalendar(&opts)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, events)
+	first := events[0].GetDate()
+	last := events[len(events)-1].GetDate()
+	fy, _, _ := first.Greg()
+	ly, _, _ := last.Greg()
+	assert.Equal(t, -1, fy)
+	assert.Equal(t, 1, ly)
+}
+
 func TestHebrewCalendarZmanimOnly(t *testing.T) {
 	assert := assert.New(t)
 	loc := zmanim.LookupCity("Amsterdam")


### PR DESCRIPTION
When a user requested a calendar starting in a BC year (e.g. year=-1) with
the default NumYears=1, getStartAndEnd computed the end as
greg.ToRD(year+numYears, January, 1) = greg.ToRD(0, ...), which panics
because the historical Gregorian calendar has no year 0 (1 BC is
immediately followed by 1 AD). Bump the end year past 0 whenever the
range crosses the BC/AD boundary so that the requested number of years
of output is preserved.

Reported in hebcal/hebcal#310.