### PR TITLE
Add Erev Pesach chametz times to candle-lighting output (#13)

### DIFF
--- a/hebcal/candles.go
+++ b/hebcal/candles.go
@@ -201,6 +201,51 @@ func makeFastStartEnd(ev event.CalEvent, opts *CalOptions) (TimedEvent, TimedEve
 	return startEvent, endEvent
 }
 
+// makeErevPesachChametz returns the "Finish eating chametz" (sof zman achilat
+// chametz) and "Biur Chametz" (sof zman biur chametz) events for Erev Pesach.
+// It is modeled on hebcal-es6's makeErevPesachChametzEvents.
+//
+// Sof zman achilat chametz is the same as sof zman tefilla (Gra, sunrise plus 4
+// halachic hours); sof zman biur chametz is one halachic hour later. When Erev
+// Pesach falls on Shabbat, chametz cannot be burned on Shabbat, so the Biur
+// Chametz event is emitted on the Friday before instead (see makeBiurChametz)
+// and is omitted here.
+func makeErevPesachChametz(ev event.CalEvent, opts *CalOptions) []event.CalEvent {
+	hd := ev.GetDate()
+	year, month, day := hd.Greg()
+	gregDate := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+	z := zmanim.New(opts.Location, gregDate)
+	events := make([]event.CalEvent, 0, 2)
+	achilas := z.SofZmanAchilasChametz()
+	if achilas.IsZero() {
+		return events
+	}
+	achilasEv := NewTimedEvent(hd, "Finish eating chametz", 0, achilas, 0, ev, opts)
+	achilasEv.Emoji = "🍞"
+	events = append(events, achilasEv)
+	if hd.Weekday() != time.Saturday {
+		if biurEv := makeBiurChametz(hd, opts); (biurEv != TimedEvent{}) {
+			events = append(events, biurEv)
+		}
+	}
+	return events
+}
+
+// makeBiurChametz returns the "Biur Chametz" (sof zman biur chametz) event for
+// the given day, or an empty TimedEvent if the sun does not rise/set.
+func makeBiurChametz(hd hdate.HDate, opts *CalOptions) TimedEvent {
+	year, month, day := hd.Greg()
+	gregDate := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+	z := zmanim.New(opts.Location, gregDate)
+	biur := z.SofZmanBiurChametz()
+	if biur.IsZero() {
+		return TimedEvent{}
+	}
+	biurEv := NewTimedEvent(hd, "Biur Chametz", 0, biur, 0, nil, opts)
+	biurEv.Emoji = "🔥"
+	return biurEv
+}
+
 type riseSetEvent struct {
 	date hdate.HDate
 	opts *CalOptions

--- a/hebcal/chametz_test.go
+++ b/hebcal/chametz_test.go
@@ -1,0 +1,78 @@
+package hebcal_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hebcal/hebcal-go/hebcal"
+	"github.com/hebcal/hebcal-go/zmanim"
+	"github.com/stretchr/testify/assert"
+)
+
+// chametzEvents renders every event whose (locale) description mentions chametz,
+// prefixed with its weekday, Gregorian date, and emoji.
+func chametzEvents(t *testing.T, gregYear int, locale string) []string {
+	t.Helper()
+	loc := zmanim.LookupCity("Chicago")
+	opts := &hebcal.CalOptions{Year: gregYear, Location: loc, CandleLighting: true}
+	events, err := hebcal.HebrewCalendar(opts)
+	assert.NoError(t, err)
+	var out []string
+	for _, ev := range events {
+		r := ev.Render(locale)
+		if strings.Contains(strings.ToLower(r), "chametz") || strings.Contains(r, "חָמֵץ") {
+			hd := ev.GetDate()
+			y, m, d := hd.Greg()
+			dow := hd.Weekday().String()[:3]
+			out = append(out, fmt.Sprintf("%s %04d-%02d-%02d %s %s", dow, y, m, d, ev.GetEmoji(), r))
+		}
+	}
+	return out
+}
+
+// Normal year: Erev Pesach 5782 is Friday 2022-04-15. Both sof zman achilat
+// chametz and sof zman biur chametz are emitted that morning, biur one halachic
+// hour after achilat.
+func TestErevPesachChametz(t *testing.T) {
+	assert := assert.New(t)
+	expected := []string{
+		"Fri 2022-04-15 🍞 Finish eating chametz: 10:37",
+		"Fri 2022-04-15 🔥 Biur Chametz: 11:44",
+	}
+	assert.Equal(expected, chametzEvents(t, 2022, "en"))
+}
+
+// Erev Pesach on Shabbat: 14 Nisan 5781 is Saturday 2021-03-27. Chametz cannot
+// be burned on Shabbat, so Biur Chametz is moved to Friday 2021-03-26, while sof
+// zman achilat chametz stays on Shabbat.
+func TestErevPesachChametzOnShabbat(t *testing.T) {
+	assert := assert.New(t)
+	expected := []string{
+		"Fri 2021-03-26 🔥 Biur Chametz: 11:54",
+		"Sat 2021-03-27 🍞 Finish eating chametz: 10:51",
+	}
+	assert.Equal(expected, chametzEvents(t, 2021, "en"))
+}
+
+// The events carry their Hebrew translations.
+func TestErevPesachChametzHebrew(t *testing.T) {
+	assert := assert.New(t)
+	expected := []string{
+		"Fri 2022-04-15 🍞 סוֹף זְמַן אֲכִילַת חָמֵץ: 10:37",
+		"Fri 2022-04-15 🔥 בִּעוּר חָמֵץ: 11:44",
+	}
+	assert.Equal(expected, chametzEvents(t, 2022, "he"))
+}
+
+// Without candle-lighting, no chametz events are emitted.
+func TestErevPesachChametzRequiresCandleLighting(t *testing.T) {
+	assert := assert.New(t)
+	loc := zmanim.LookupCity("Chicago")
+	opts := &hebcal.CalOptions{Year: 2022, Location: loc}
+	events, err := hebcal.HebrewCalendar(opts)
+	assert.NoError(err)
+	for _, ev := range events {
+		assert.NotContains(strings.ToLower(ev.Render("en")), "chametz")
+	}
+}

--- a/hebcal/hebcal.go
+++ b/hebcal/hebcal.go
@@ -196,6 +196,13 @@ func HebrewCalendar(opts *CalOptions) ([]event.CalEvent, error) {
 				events, candlesEv = appendHolidayAndRelated(events, candlesEv, holidayEv, opts)
 			}
 		}
+		// When Erev Pesach falls on Shabbat, burning chametz is moved to the
+		// Friday before (13 Nisan), since chametz cannot be burned on Shabbat.
+		if opts.CandleLighting && dow == time.Friday && hd.Month() == hdate.Nisan && hd.Day() == 13 {
+			if biurEv := makeBiurChametz(hd, opts); (biurEv != TimedEvent{}) {
+				events = append(events, biurEv)
+			}
+		}
 		for _, userEv := range userEvents {
 			if abs == userEv.Date.Abs() {
 				events = append(events, userEv)
@@ -504,6 +511,9 @@ func appendHolidayAndRelated(events []event.CalEvent, candlesEv TimedEvent, ev e
 	if (!opts.YomKippurKatan && (mask&event.YOM_KIPPUR_KATAN) != 0) ||
 		(opts.NoModern && (mask&event.MODERN_HOLIDAY) != 0) {
 		return events, candlesEv // bail out early
+	}
+	if opts.CandleLighting && ev.Render("en") == "Erev Pesach" {
+		events = append(events, makeErevPesachChametz(ev, opts)...)
 	}
 	isMajorFast := (mask & event.MAJOR_FAST) != 0
 	isMinorFast := (mask & event.MINOR_FAST) != 0

--- a/zmanim/zmanim.go
+++ b/zmanim/zmanim.go
@@ -276,6 +276,20 @@ func (z *Zmanim) SofZmanTfilla() time.Time {
 	return z.HourOffset(4)
 }
 
+// SofZmanAchilasChametz is the latest time to eat chametz on Erev Pesach
+// according to the Gra. It is the same as [Zmanim.SofZmanTfilla], sunrise plus 4
+// halachic hours.
+func (z *Zmanim) SofZmanAchilasChametz() time.Time {
+	return z.HourOffset(4)
+}
+
+// SofZmanBiurChametz is the latest time to burn (dispose of) chametz on Erev
+// Pesach according to the Gra: sunrise plus 5 halachic hours, one halachic hour
+// after [Zmanim.SofZmanAchilasChametz].
+func (z *Zmanim) SofZmanBiurChametz() time.Time {
+	return z.HourOffset(5)
+}
+
 func (z *Zmanim) sofZmanMGA(hours float64) time.Time {
 	alot72 := z.SunriseOffset(-72, false)
 	tzeit72 := z.SunsetOffset(72, false)


### PR DESCRIPTION
Implements #13. When candle-lighting (`-c`) is requested, emit **sof zman achilat chametz** ("Finish eating chametz") and **sof zman biur chametz** ("Biur Chametz") on Erev Pesach — alongside candle-lighting, as concluded in the issue discussion (like the existing fast start/end times). Modeled on hebcal-es6's `makeErevPesachChametzEvents`.

## Changes

**`zmanim/zmanim.go`** — two new `Zmanim` methods:
- `SofZmanAchilasChametz()` — sunrise + 4 halachic hours (same as `SofZmanTfilla`, Gra)
- `SofZmanBiurChametz()` — sunrise + 5 halachic hours (one halachic hour later)

**`hebcal/candles.go`** — `makeErevPesachChametz` / `makeBiurChametz` build the `TimedEvent`s, using the existing locale keys `"Finish eating chametz"` and `"Biur Chametz"` (both already translated in `github.com/hebcal/locales`), with 🍞 and 🔥 emoji.

**`hebcal/hebcal.go`** — `appendHolidayAndRelated` emits both zmanim on Erev Pesach. Handles the **Erev-Pesach-on-Shabbat** edge case: chametz cannot be burned on Shabbat, so Biur Chametz is emitted on the Friday before (13 Nisan) while sof zman achilat chametz stays on Erev Pesach.

## Output (Chicago)

Normal year (Erev Pesach 5782 = Friday 2022-04-15):
```
Fri 2022-04-15 🍞 Finish eating chametz: 10:37
Fri 2022-04-15 🔥 Biur Chametz: 11:44
```

Erev Pesach on Shabbat (14 Nisan 5781 = Saturday 2021-03-27):
```
Fri 2021-03-26 🔥 Biur Chametz: 11:54
Sat 2021-03-27 🍞 Finish eating chametz: 10:51
```

## Tests

`hebcal/chametz_test.go` covers a normal year, the Erev-Pesach-on-Shabbat case, Hebrew rendering, and that nothing is emitted without candle-lighting. Full suite and `go vet ./...` pass.

## Note for review

The gate in `appendHolidayAndRelated` uses `ev.Render("en") == "Erev Pesach"` to mirror es6's `getDesc() === EREV_PESACH`. Happy to switch to a flag-based check if preferred.

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CmSgHoAWaHsVFU7bLLUXzJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmSgHoAWaHsVFU7bLLUXzJ)_