### PR TITLE
Add CalOptions.UseElevation for elevation-aware zmanim

### DIFF
--- a/hebcal/candles.go
+++ b/hebcal/candles.go
@@ -100,6 +100,18 @@ func (ev TimedEvent) Basename() string {
 	return ev.Desc
 }
 
+// newZmanim builds a Zmanim for the Gregorian date of hd at the options'
+// Location, honoring opts.UseElevation so that sunrise/sunset-based times
+// account for the location's elevation when requested. Degree-based zmanim are
+// never affected by elevation.
+func newZmanim(hd hdate.HDate, opts *CalOptions) zmanim.Zmanim {
+	year, month, day := hd.Greg()
+	gregDate := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+	z := zmanim.New(opts.Location, gregDate)
+	z.UseElevation = opts.UseElevation
+	return z
+}
+
 func makeCandleEvent(hd hdate.HDate, opts *CalOptions, ev event.CalEvent) TimedEvent {
 	havdalahTitle := false
 	useHavdalahOffset := false
@@ -127,10 +139,7 @@ func makeCandleEvent(hd hdate.HDate, opts *CalOptions, ev event.CalEvent) TimedE
 	if useHavdalahOffset {
 		offset = opts.HavdalahMins
 	}
-	year, month, day := hd.Greg()
-	gregDate := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
-	loc := opts.Location
-	z := zmanim.New(loc, gregDate)
+	z := newZmanim(hd, opts)
 	var eventTime time.Time
 	if offset != 0 {
 		eventTime = z.SunsetOffset(offset, true)
@@ -159,10 +168,7 @@ func makeChanukahCandleLighting(ev event.HolidayEvent, opts *CalOptions) TimedEv
 		timedEv.ChanukahDay = ev.ChanukahDay
 		return timedEv
 	}
-	loc := opts.Location
-	year, month, day := hd.Greg()
-	gregDate := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
-	z := zmanim.New(loc, gregDate)
+	z := newZmanim(hd, opts)
 	candleLightingTime := z.BeinHashmashos()
 	if candleLightingTime.IsZero() {
 		return TimedEvent{} // no sunset
@@ -176,11 +182,8 @@ func makeChanukahCandleLighting(ev event.HolidayEvent, opts *CalOptions) TimedEv
 }
 
 func makeFastStartEnd(ev event.CalEvent, opts *CalOptions) (TimedEvent, TimedEvent) {
-	year, month, day := ev.GetDate().Greg()
-	gregDate := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
-	loc := opts.Location
-	z := zmanim.New(loc, gregDate)
 	hd := ev.GetDate()
+	z := newZmanim(hd, opts)
 	desc := ev.Render("en")
 	flags := ev.GetFlags()
 	var startEvent, endEvent TimedEvent
@@ -212,9 +215,7 @@ func makeFastStartEnd(ev event.CalEvent, opts *CalOptions) (TimedEvent, TimedEve
 // and is omitted here.
 func makeErevPesachChametz(ev event.CalEvent, opts *CalOptions) []event.CalEvent {
 	hd := ev.GetDate()
-	year, month, day := hd.Greg()
-	gregDate := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
-	z := zmanim.New(opts.Location, gregDate)
+	z := newZmanim(hd, opts)
 	events := make([]event.CalEvent, 0, 2)
 	achilas := z.SofZmanAchilasChametz()
 	if achilas.IsZero() {
@@ -234,9 +235,7 @@ func makeErevPesachChametz(ev event.CalEvent, opts *CalOptions) []event.CalEvent
 // makeBiurChametz returns the "Biur Chametz" (sof zman biur chametz) event for
 // the given day, or an empty TimedEvent if the sun does not rise/set.
 func makeBiurChametz(hd hdate.HDate, opts *CalOptions) TimedEvent {
-	year, month, day := hd.Greg()
-	gregDate := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
-	z := zmanim.New(opts.Location, gregDate)
+	z := newZmanim(hd, opts)
 	biur := z.SofZmanBiurChametz()
 	if biur.IsZero() {
 		return TimedEvent{}
@@ -256,10 +255,7 @@ func (ev riseSetEvent) GetDate() hdate.HDate {
 }
 
 func (ev riseSetEvent) Render(locale string) string {
-	loc := ev.opts.Location
-	year, month, day := ev.date.Greg()
-	gregDate := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
-	z := zmanim.New(loc, gregDate)
+	z := newZmanim(ev.date, ev.opts)
 	rise := z.Sunrise()
 	set := z.Sunset()
 	riseStr := formatTime(&rise, ev.opts)
@@ -280,10 +276,7 @@ func (ev riseSetEvent) Basename() string {
 }
 
 func dailyZemanim(date hdate.HDate, opts *CalOptions) []event.CalEvent {
-	loc := opts.Location
-	year, month, day := date.Greg()
-	gregDate := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
-	z := zmanim.New(loc, gregDate)
+	z := newZmanim(date, opts)
 	times := []struct {
 		desc string
 		t    time.Time

--- a/hebcal/elevation_test.go
+++ b/hebcal/elevation_test.go
@@ -1,0 +1,69 @@
+package hebcal_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hebcal/hebcal-go/hebcal"
+	"github.com/hebcal/hebcal-go/zmanim"
+	"github.com/stretchr/testify/assert"
+)
+
+// findOnDate returns the first event rendered in English on the given Gregorian
+// date whose description starts with prefix, or "".
+func findOnDate(t *testing.T, opts *hebcal.CalOptions, y, m, d int, prefix string) string {
+	t.Helper()
+	events, err := hebcal.HebrewCalendar(opts)
+	assert.NoError(t, err)
+	for _, ev := range events {
+		gy, gm, gd := ev.GetDate().Greg()
+		if gy == y && int(gm) == m && gd == d {
+			r := ev.Render("en")
+			if strings.HasPrefix(r, prefix) {
+				return r
+			}
+		}
+	}
+	return ""
+}
+
+// TestUseElevationCalOption verifies that CalOptions.UseElevation flows through
+// to candle-lighting and daily zmanim: sunrise/sunset-based times shift with the
+// location's elevation, while degree-based zmanim do not. Jerusalem has an
+// elevation of 786m.
+func TestUseElevationCalOption(t *testing.T) {
+	assert := assert.New(t)
+	loc := zmanim.LookupCity("Jerusalem")
+	newOpts := func(useElevation bool) *hebcal.CalOptions {
+		return &hebcal.CalOptions{
+			Year: 2022, Month: 4, Location: loc,
+			CandleLighting: true, DailyZmanim: true, UseElevation: useElevation,
+		}
+	}
+	y, m, d := 2022, 4, 8 // a Friday in Jerusalem
+
+	// Candle lighting (sunset-based) is later at elevation.
+	assert.Equal("Candle lighting: 6:23", findOnDate(t, newOpts(false), y, m, d, "Candle lighting"))
+	assert.Equal("Candle lighting: 6:27", findOnDate(t, newOpts(true), y, m, d, "Candle lighting"))
+
+	// Sunrise (sunset-based) is earlier at elevation.
+	assert.Equal("Sunrise: 6:19", findOnDate(t, newOpts(false), y, m, d, "Sunrise"))
+	assert.Equal("Sunrise: 6:14", findOnDate(t, newOpts(true), y, m, d, "Sunrise"))
+
+	// Alot HaShachar (degree-based) is unaffected by elevation.
+	assert.Equal("Alot HaShachar: 5:05", findOnDate(t, newOpts(false), y, m, d, "Alot HaShachar"))
+	assert.Equal("Alot HaShachar: 5:05", findOnDate(t, newOpts(true), y, m, d, "Alot HaShachar"))
+}
+
+// TestUseElevationDefaultFalse confirms the default (unset) matches the
+// non-elevation calculation.
+func TestUseElevationDefaultFalse(t *testing.T) {
+	assert := assert.New(t)
+	loc := zmanim.LookupCity("Jerusalem")
+	dflt := &hebcal.CalOptions{Year: 2022, Month: 4, Location: loc, CandleLighting: true}
+	explicit := &hebcal.CalOptions{Year: 2022, Month: 4, Location: loc, CandleLighting: true, UseElevation: false}
+	assert.Equal(
+		findOnDate(t, dflt, 2022, 4, 8, "Candle lighting"),
+		findOnDate(t, explicit, 2022, 4, 8, "Candle lighting"),
+	)
+}

--- a/hebcal/hebcal.go
+++ b/hebcal/hebcal.go
@@ -90,6 +90,9 @@ These defaults can be changed using these options:
   - opts.HavdalahDeg - degrees for solar depression for Havdalah.
     Default is 8.5 degrees for 3 small stars. Use 7.083 degress for 3 medium-sized stars.
     Havdalah times are supressed when opts.HavdalahDeg=0.
+  - opts.UseElevation - use the location's elevation for sunrise/sunset-based times
+    (candle-lighting, Havdalah, fast start/end, and the sunset-based daily zmanim).
+    Degree-based zmanim (dawn, tzeit, alot, misheyakir) are never affected by elevation.
 
 If both opts.CandleLighting=true and opts.Location is specified,
 Chanukah candle-lighting times and minor fast start/end times will also be generated.

--- a/hebcal/options.go
+++ b/hebcal/options.go
@@ -70,6 +70,12 @@ type CalOptions struct {
 	End hdate.HDate
 	/* calculate candle-lighting and havdalah times */
 	CandleLighting bool
+	// UseElevation enables elevation-aware sunrise and sunset (and the halachic
+	// times derived from them) using the Location's elevation. Degree-based
+	// zmanim, such as dawn, dusk, tzeit, alot haShachar and misheyakir, estimate
+	// the amount of light in the sky and are intentionally never affected by
+	// elevation. Defaults to false.
+	UseElevation bool
 	/* minutes before sundown to light candles (default 18) */
 	CandleLightingMins int
 	// minutes after sundown for Havdalah (typical values are 42, 50, or 72).


### PR DESCRIPTION
Mirrors hebcal-es6's elevation support at the calendar level: adds `CalOptions.UseElevation` (default `false`) and threads it consistently through every zmanim calculation used by `HebrewCalendar`.

## Changes

- **`hebcal/options.go`** — new `CalOptions.UseElevation bool` (default `false`), documented.
- **`hebcal/candles.go`** — added a `newZmanim(hd, opts)` helper that builds the `zmanim.Zmanim` and sets `UseElevation` from the options, then routed **all 7** construction sites through it: candle-lighting / Havdalah, Chanukah candles, fast start/end, Erev Pesach chametz + biur, the sunrise/sunset event, and the daily zmanim list. This also removes the duplicated Gregorian-date construction at each site.
- **`hebcal/hebcal.go`** — documented the option in the `HebrewCalendar` doc block.

## Behavior

Matches hebcal-es6: with `UseElevation: true`, sunrise/sunset-based times (and the halachic times derived from them — candle-lighting, Havdalah, fast start/end, sunset-based daily zmanim) account for the location's elevation. Degree-based zmanim (dawn, tzeit, alot, misheyakir) estimate the amount of light in the sky and are never affected by elevation.

## Verification (Jerusalem, 786m, 2022-04-08)

| zman | UseElevation=false | UseElevation=true |
| --- | --- | --- |
| Candle lighting | 6:23 | 6:27 |
| Sunrise | 6:19 | 6:14 |
| Alot HaShachar (degree-based) | 5:05 | 5:05 |

Tests (`hebcal/elevation_test.go`) cover the shifts above and that the default (unset) equals an explicit `UseElevation: false`. Full suite and `go vet ./...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CmSgHoAWaHsVFU7bLLUXzJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmSgHoAWaHsVFU7bLLUXzJ)_