### PR TITLE
zmanim: compute sofZmanMGA from sea-level sunrise/sunset

### DIFF
--- a/zmanim/zmanim.go
+++ b/zmanim/zmanim.go
@@ -291,10 +291,19 @@ func (z *Zmanim) SofZmanBiurChametz() time.Time {
 }
 
 func (z *Zmanim) sofZmanMGA(hours float64) time.Time {
-	alot72 := z.SunriseOffset(-72, false)
-	tzeit72 := z.SunsetOffset(72, false)
-	alot72sec := alot72.Unix()
-	temporalHour := float64(tzeit72.Unix()-alot72sec) / 12.0 // sec in hour
+	// The MGA "72 minute" day is measured from 72 minutes before sea-level
+	// sunrise to 72 minutes after sea-level sunset, regardless of elevation
+	// (matching @hebcal/core, which forces sea level here). Using the
+	// elevation-adjusted sunrise/sunset would shift these times by a minute
+	// or more when UseElevation is set.
+	sunrise := z.SeaLevelSunrise()
+	sunset := z.SeaLevelSunset()
+	if sunrise.IsZero() || sunset.IsZero() {
+		return time.Time{}
+	}
+	alot72sec := sunrise.Add(-72 * time.Minute).Unix()
+	tzeit72sec := sunset.Add(72 * time.Minute).Unix()
+	temporalHour := float64(tzeit72sec-alot72sec) / 12.0 // sec in hour
 	seconds := alot72sec + int64(hours*temporalHour)
 	return time.Unix(seconds, 0).In(z.TimeZone)
 }

--- a/zmanim/zmanim_extra_test.go
+++ b/zmanim/zmanim_extra_test.go
@@ -33,6 +33,10 @@ func TestExtraZmanim(t *testing.T) {
 	}
 
 	z := zmanim.New(&loc, dt) // UseElevation defaults to false
+	// The MGA "72 minute" sof zman is measured from sea level, so it is the
+	// same with or without elevation (see the ze assertions below).
+	assertClose(t, "sofZmanShmaMGA", z.SofZmanShmaMGA(), "2024-04-26T08:41:40")
+	assertClose(t, "sofZmanTfillaMGA", z.SofZmanTfillaMGA(), "2024-04-26T10:00:08")
 	assertClose(t, "seaLevelSunrise", z.SeaLevelSunrise(), "2024-04-26T05:58:14")
 	assertClose(t, "seaLevelSunset", z.SeaLevelSunset(), "2024-04-26T19:15:58")
 	assertClose(t, "sofZmanShmaMGA16Point1", z.SofZmanShmaMGA16Point1(), "2024-04-26T08:38:56")
@@ -54,6 +58,10 @@ func TestExtraZmanim(t *testing.T) {
 	ze.UseElevation = true
 	assertClose(t, "minchaGedolaMGA(elev)", ze.MinchaGedolaMGA(), "2024-04-26T13:16:42")
 	assertClose(t, "minchaKetanaMGA(elev)", ze.MinchaKetanaMGA(), "2024-04-26T17:14:21")
+	// The MGA 72-minute sof zman uses sea-level sunrise/sunset, so elevation
+	// must not change it (regression test for the elevation-aware bug).
+	assertClose(t, "sofZmanShmaMGA(elev)", ze.SofZmanShmaMGA(), "2024-04-26T08:41:40")
+	assertClose(t, "sofZmanTfillaMGA(elev)", ze.SofZmanTfillaMGA(), "2024-04-26T10:00:08")
 	// seaLevel variants ignore elevation.
 	assertClose(t, "seaLevelSunrise(elev)", ze.SeaLevelSunrise(), "2024-04-26T05:58:14")
 	assertClose(t, "seaLevelSunset(elev)", ze.SeaLevelSunset(), "2024-04-26T19:15:58")


### PR DESCRIPTION
SofZmanShmaMGA and SofZmanTfillaMGA define the MGA "72 minute" day as 72 minutes before sea-level sunrise to 72 minutes after sea-level sunset, independent of elevation. sofZmanMGA was using the elevation-adjusted SunriseOffset/SunsetOffset, so with UseElevation set the result was shifted by a minute or more, disagreeing with @hebcal/core (which forces sea level here) and with the documented definition.

Use SeaLevelSunrise/SeaLevelSunset instead, and add a regression test asserting these times are identical with and without elevation.


Claude-Session: https://claude.ai/code/session_01CmSgHoAWaHsVFU7bLLUXzJ