### PR TITLE
event: add GetCategories to CalEvent

### DIFF
--- a/event/categories_test.go
+++ b/event/categories_test.go
@@ -1,0 +1,54 @@
+package event
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/hebcal/hdate"
+)
+
+func TestHolidayEventGetCategories(t *testing.T) {
+	tests := []struct {
+		desc  string
+		flags HolidayFlags
+		chm   int
+		want  []string
+	}{
+		{"Pesach VII", CHAG, 0, []string{"holiday", "major"}},
+		{"Yom Kippur", CHAG | MAJOR_FAST, 0, []string{"holiday", "major", "fast"}},
+		{"Chanukah: 3 Candles", CHANUKAH_CANDLES | MINOR_HOLIDAY, 0, []string{"holiday", "minor"}},
+		{"Tzom Gedaliah", MINOR_FAST, 0, []string{"holiday", "fast"}},
+		{"Tu BiShvat", MINOR_HOLIDAY, 0, []string{"holiday", "minor"}},
+		{"Yom HaAtzma'ut", MODERN_HOLIDAY, 0, []string{"holiday", "modern"}},
+		{"Shabbat Shekalim", SPECIAL_SHABBAT, 0, []string{"holiday", "shabbat"}},
+		{"Rosh Chodesh Sivan", ROSH_CHODESH, 0, []string{"roshchodesh"}},
+		{"Shabbat Mevarchim Chodesh Sivan", SHABBAT_MEVARCHIM, 0, []string{"mevarchim"}},
+		{"Pesach II (CH''M)", CHUL_ONLY, 1, []string{"holiday", "major", "cholhamoed"}},
+		// flags alone inconclusive: minor-holiday fallback list vs major default
+		{"Lag BaOmer", 0, 0, []string{"holiday", "minor"}},
+		{"Erev Purim", EREV, 0, []string{"holiday", "minor"}},
+		{"Some Random Holiday", 0, 0, []string{"holiday", "major"}},
+	}
+	for _, tc := range tests {
+		ev := HolidayEvent{Date: hdate.New(5784, hdate.Sivan, 1), Desc: tc.desc, Flags: tc.flags, CholHaMoedDay: tc.chm}
+		if got := ev.GetCategories(); !reflect.DeepEqual(got, tc.want) {
+			t.Errorf("%q %b: GetCategories() = %v, want %v", tc.desc, tc.flags, got, tc.want)
+		}
+	}
+}
+
+func TestCategoriesFromFlags(t *testing.T) {
+	if got := CategoriesFromFlags(0); !reflect.DeepEqual(got, []string{"unknown"}) {
+		t.Errorf("CategoriesFromFlags(0) = %v, want [unknown]", got)
+	}
+	if got := CategoriesFromFlags(PARSHA_HASHAVUA); !reflect.DeepEqual(got, []string{"parashat"}) {
+		t.Errorf("CategoriesFromFlags(PARSHA_HASHAVUA) = %v", got)
+	}
+	// the returned slice must be a copy the caller can mutate safely
+	a := CategoriesFromFlags(MAJOR_FAST)
+	a[0] = "mutated"
+	b := CategoriesFromFlags(MAJOR_FAST)
+	if b[0] != "holiday" {
+		t.Errorf("CategoriesFromFlags returned a shared slice: %v", b)
+	}
+}

--- a/event/event.go
+++ b/event/event.go
@@ -93,4 +93,43 @@ type CalEvent interface {
 	// For many holidays the basename and the event description are
 	// the same.
 	Basename() string
+	// GetCategories returns the category and optional sub-categories for this
+	// event, e.g. ["holiday", "major", "fast"] or ["roshchodesh"]. The first
+	// element is the primary category.
+	GetCategories() []string
+}
+
+// flagToCategory maps an event flag to its category and sub-categories, in
+// priority order (the first matching flag wins). It mirrors the flagToCategory
+// table in @hebcal/core.
+var flagToCategory = []struct {
+	flag HolidayFlags
+	cats []string
+}{
+	{MAJOR_FAST, []string{"holiday", "major", "fast"}},
+	{CHANUKAH_CANDLES, []string{"holiday", "minor"}},
+	{HEBREW_DATE, []string{"hebdate"}},
+	{MINOR_FAST, []string{"holiday", "fast"}},
+	{MINOR_HOLIDAY, []string{"holiday", "minor"}},
+	{MODERN_HOLIDAY, []string{"holiday", "modern"}},
+	{MOLAD, []string{"molad"}},
+	{OMER_COUNT, []string{"omer"}},
+	{PARSHA_HASHAVUA, []string{"parashat"}},
+	{ROSH_CHODESH, []string{"roshchodesh"}},
+	{SHABBAT_MEVARCHIM, []string{"mevarchim"}},
+	{SPECIAL_SHABBAT, []string{"holiday", "shabbat"}},
+	{USER_EVENT, []string{"user"}},
+}
+
+// CategoriesFromFlags returns the category and sub-categories implied by an
+// event's flag bitmask, matching the base Event.getCategories() in
+// @hebcal/core. It returns ["unknown"] when no flag matches. The returned
+// slice is a fresh copy that the caller may modify.
+func CategoriesFromFlags(mask HolidayFlags) []string {
+	for _, fc := range flagToCategory {
+		if mask&fc.flag != 0 {
+			return append([]string(nil), fc.cats...)
+		}
+	}
+	return []string{"unknown"}
 }

--- a/event/hdate.go
+++ b/event/hdate.go
@@ -50,6 +50,10 @@ func (ev hebrewDateEvent) Basename() string {
 	return ev.Date.String()
 }
 
+func (ev hebrewDateEvent) GetCategories() []string {
+	return CategoriesFromFlags(ev.GetFlags())
+}
+
 func NewHebrewDateEvent(hd hdate.HDate) CalEvent {
 	return hebrewDateEvent{Date: hd}
 }

--- a/event/holiday.go
+++ b/event/holiday.go
@@ -94,3 +94,35 @@ func (ev HolidayEvent) Basename() string {
 	}
 	return str
 }
+
+// minorHolidays are holidays whose flags do not mark them minor but which are
+// nevertheless categorized as minor, matching @hebcal/core HolidayEvent.
+var minorHolidays = map[string]bool{
+	"Lag BaOmer":             true,
+	"Leil Selichot":          true,
+	"Pesach Sheni":           true,
+	"Erev Purim":             true,
+	"Purim Katan":            true,
+	"Shushan Purim":          true,
+	"Tu B'Av":                true,
+	"Tu BiShvat":             true,
+	"Rosh Hashana LaBehemot": true,
+}
+
+// GetCategories returns the category and sub-categories for a holiday,
+// mirroring HolidayEvent.getCategories() in @hebcal/core: chol hamoed days are
+// major, otherwise the flag-based category is used, falling back to a minor or
+// major holiday when the flags alone are inconclusive.
+func (ev HolidayEvent) GetCategories() []string {
+	if ev.CholHaMoedDay != 0 {
+		return []string{"holiday", "major", "cholhamoed"}
+	}
+	cats := CategoriesFromFlags(ev.Flags)
+	if cats[0] != "unknown" {
+		return cats
+	}
+	if minorHolidays[ev.Desc] {
+		return []string{"holiday", "minor"}
+	}
+	return []string{"holiday", "major"}
+}

--- a/event/molad.go
+++ b/event/molad.go
@@ -78,3 +78,7 @@ func (ev moladEvent) GetEmoji() string {
 func (ev moladEvent) Basename() string {
 	return "Molad " + ev.MonthName
 }
+
+func (ev moladEvent) GetCategories() []string {
+	return CategoriesFromFlags(ev.GetFlags())
+}

--- a/event/parsha.go
+++ b/event/parsha.go
@@ -40,3 +40,7 @@ func (ev parshaEvent) GetEmoji() string {
 func (ev parshaEvent) Basename() string {
 	return strings.Join(ev.Parsha.Name, "-")
 }
+
+func (ev parshaEvent) GetCategories() []string {
+	return CategoriesFromFlags(ev.GetFlags())
+}

--- a/event/user.go
+++ b/event/user.go
@@ -6,8 +6,8 @@ import (
 
 // UserEvent is for Yahrzeit or Birthday
 type UserEvent struct {
-	Date          hdate.HDate  // Date of occurrence
-	Desc          string       // Description
+	Date hdate.HDate // Date of occurrence
+	Desc string      // Description
 }
 
 func (ev UserEvent) GetDate() hdate.HDate {
@@ -28,4 +28,8 @@ func (ev UserEvent) GetEmoji() string {
 
 func (ev UserEvent) Basename() string {
 	return ev.Desc
+}
+
+func (ev UserEvent) GetCategories() []string {
+	return CategoriesFromFlags(ev.GetFlags())
 }

--- a/hebcal/candles.go
+++ b/hebcal/candles.go
@@ -100,6 +100,25 @@ func (ev TimedEvent) Basename() string {
 	return ev.Desc
 }
 
+// GetCategories returns the category and sub-categories for a timed event,
+// keyed by its description, matching TimedEvent.getCategories() in
+// @hebcal/core.
+func (ev TimedEvent) GetCategories() []string {
+	switch ev.Desc {
+	case "Candle lighting":
+		return []string{"candles"}
+	case "Havdalah":
+		return []string{"havdalah"}
+	case "Fast begins", "Fast ends":
+		return []string{"zmanim", "fast"}
+	case "Finish eating chametz":
+		return []string{"zmanim", "achilasChametz"}
+	case "Biur Chametz":
+		return []string{"zmanim", "biurChametz"}
+	}
+	return []string{"unknown"}
+}
+
 // newZmanim builds a Zmanim for the Gregorian date of hd at the options'
 // Location, honoring opts.UseElevation so that sunrise/sunset-based times
 // account for the location's elevation when requested. Degree-based zmanim are
@@ -273,6 +292,10 @@ func (ev riseSetEvent) GetEmoji() string {
 
 func (ev riseSetEvent) Basename() string {
 	return ev.Render("en")
+}
+
+func (ev riseSetEvent) GetCategories() []string {
+	return []string{"zmanim"}
 }
 
 func dailyZemanim(date hdate.HDate, opts *CalOptions) []event.CalEvent {

--- a/hebcal/categories_test.go
+++ b/hebcal/categories_test.go
@@ -1,0 +1,33 @@
+package hebcal
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/hebcal/hdate"
+	"github.com/hebcal/hebcal-go/event"
+)
+
+func TestTimedEventGetCategories(t *testing.T) {
+	hd := hdate.New(5784, hdate.Nisan, 14)
+	when := time.Date(2024, time.April, 22, 19, 0, 0, 0, time.UTC)
+	opts := &CalOptions{}
+	tests := []struct {
+		desc string
+		want []string
+	}{
+		{"Candle lighting", []string{"candles"}},
+		{"Havdalah", []string{"havdalah"}},
+		{"Fast begins", []string{"zmanim", "fast"}},
+		{"Fast ends", []string{"zmanim", "fast"}},
+		{"Finish eating chametz", []string{"zmanim", "achilasChametz"}},
+		{"Biur Chametz", []string{"zmanim", "biurChametz"}},
+	}
+	for _, tc := range tests {
+		ev := NewTimedEvent(hd, tc.desc, event.LIGHT_CANDLES, when, 0, nil, opts)
+		if got := ev.GetCategories(); !reflect.DeepEqual(got, tc.want) {
+			t.Errorf("%q: GetCategories() = %v, want %v", tc.desc, got, tc.want)
+		}
+	}
+}

--- a/omer/omer.go
+++ b/omer/omer.go
@@ -89,6 +89,10 @@ func (ev OmerEvent) Basename() string {
 	return "Omer"
 }
 
+func (ev OmerEvent) GetCategories() []string {
+	return event.CategoriesFromFlags(ev.GetFlags())
+}
+
 func (ev OmerEvent) GetWeeks() int {
 	if ev.DaysWithinWeeks == 7 {
 		return ev.WeekNumber


### PR DESCRIPTION
Add a GetCategories() []string method to the CalEvent interface and implement it on every event type, mirroring Event.getCategories() (and the HolidayEvent / TimedEvent overrides) in @hebcal/core. It returns the event's category and optional sub-categories, e.g. ["holiday","major", "fast"], ["roshchodesh"], ["candles"], or ["zmanim","fast"].

  - CategoriesFromFlags(mask) exposes the base flagToCategory mapping.
  - HolidayEvent applies the chol-hamoed / minor-holiday / major-holiday fallbacks used when the flags alone are inconclusive.
  - TimedEvent keys candles/havdalah and the fast/chametz zmanim off its description.

This lets API consumers categorize events without re-porting the table and overrides in each wrapper.


Claude-Session: https://claude.ai/code/session_01CmSgHoAWaHsVFU7bLLUXzJ