### PR TITLE
event: align English molad memo format with @hebcal/core

### DIFF
--- a/event/molad.go
+++ b/event/molad.go
@@ -10,17 +10,59 @@ import (
 )
 
 type moladEvent struct {
-	Date      hdate.HDate
-	Molad     molad.Molad
-	MonthName string
+	Date        hdate.HDate
+	Molad       molad.Molad
+	MonthName   string
+	CountryCode string // used to pick a 12- or 24-hour clock for the announcement
 }
 
-func NewMoladEvent(date hdate.HDate, m molad.Molad, monthName string) CalEvent {
+// NewMoladEvent constructs a molad announcement event. countryCode selects the
+// wall-clock format used in non-Hebrew locales (12-hour with am/pm for the
+// United States and other 12-hour countries, 24-hour elsewhere); pass "" for
+// the default (12-hour), matching @hebcal/core.
+func NewMoladEvent(date hdate.HDate, m molad.Molad, monthName string, countryCode string) CalEvent {
 	return moladEvent{
-		Date:      date,
-		Molad:     m,
-		MonthName: monthName,
+		Date:        date,
+		Molad:       m,
+		MonthName:   monthName,
+		CountryCode: countryCode,
 	}
+}
+
+// hour12Countries lists the ISO country codes that use a 12-hour clock, matching
+// the hour12cc table in @hebcal/core reformatTimeStr.
+var hour12Countries = map[string]bool{
+	"US": true, "CA": true, "BR": true, "AU": true, "NZ": true, "DO": true,
+	"PR": true, "GR": true, "IN": true, "KR": true, "NP": true, "ZA": true,
+}
+
+// moladTimeStr formats the molad's wall-clock time, matching @hebcal/core
+// reformatTimeStr(`${hour}:${pad2(min)}`, "pm", options): 12-hour with an
+// am/pm suffix in 12-hour countries, 24-hour otherwise.
+func moladTimeStr(hour, minute int, cc string) string {
+	if cc == "" {
+		cc = "US"
+	}
+	if !hour12Countries[cc] {
+		return fmt.Sprintf("%d:%02d", hour, minute)
+	}
+	suffix := "am"
+	h := hour
+	if hour >= 12 {
+		suffix = "pm"
+		if hour > 12 {
+			h = hour - 12
+		}
+	} else if hour == 0 {
+		h = 12
+	}
+	return fmt.Sprintf("%d:%02d%s", h, minute, suffix)
+}
+
+// smartApostrophe converts a straight apostrophe to a typographic one (e.g.
+// "Sh'vat" => "Sh’vat"), matching @hebcal/core.
+func smartApostrophe(s string) string {
+	return strings.ReplaceAll(s, "'", "’")
 }
 
 func (ev moladEvent) GetDate() hdate.HDate {
@@ -54,17 +96,25 @@ func (ev moladEvent) Render(locale string) string {
 			ampm = night
 		}
 		str := fmt.Sprintf("מוֹלָד הָלְּבָנָה %s יִהְיֶה בַּיּוֹם %s בשָׁבוּעַ, "+
-			"בְּשָׁעָה %d %s, ו-%d דַּקּוֹת "+"ו-%d חֲלָקִים",
+			"בְּשָׁעָה %d %s, ו-%d דַּקּוֹת",
 			monthStr, dow,
-			ev.Molad.Hours, ampm, ev.Molad.Minutes, ev.Molad.Chalakim)
+			ev.Molad.Hours, ampm, ev.Molad.Minutes)
+		if ev.Molad.Chalakim != 0 {
+			str += fmt.Sprintf(" ו-%d חֲלָקִים", ev.Molad.Chalakim)
+		}
 		if locale == "he-x-nonikud" {
 			str = locales.HebrewStripNikkud(str)
 		}
 		return str
 	}
-	return fmt.Sprintf("Molad %s: %s, %d minutes and %d chalakim after %d:00",
-		monthStr, ev.Molad.Date.Weekday().String()[0:3],
-		ev.Molad.Minutes, ev.Molad.Chalakim, ev.Molad.Hours)
+	month := smartApostrophe(monthStr)
+	dow := ev.Molad.Date.Weekday().String()
+	timeStr := moladTimeStr(ev.Molad.Hours, ev.Molad.Minutes, ev.CountryCode)
+	result := fmt.Sprintf("Molad %s: %s, %s", month, dow, timeStr)
+	if ev.Molad.Chalakim != 0 {
+		result += fmt.Sprintf(" and %d chalakim", ev.Molad.Chalakim)
+	}
+	return result
 }
 
 func (ev moladEvent) GetFlags() HolidayFlags {

--- a/hebcal/hebcal.go
+++ b/hebcal/hebcal.go
@@ -270,7 +270,11 @@ func HebrewCalendar(opts *CalOptions) ([]event.CalEvent, error) {
 		if opts.Molad && dow == time.Saturday && hd.Month() != hdate.Elul && hd.Day() >= 23 && hd.Day() <= 29 {
 			nextMonthName, nextMonth := nextMonthName(hd.Year(), hd.Month())
 			molad := molad.New(hd.Year(), nextMonth)
-			events = append(events, event.NewMoladEvent(hd, molad, nextMonthName))
+			cc := ""
+			if opts.Location != nil {
+				cc = opts.Location.CountryCode
+			}
+			events = append(events, event.NewMoladEvent(hd, molad, nextMonthName, cc))
 		}
 		if (opts.AddHebrewDates && (!opts.WeeklyAbbreviated || dow == firstWeekday)) ||
 			((opts.AddHebrewDates || opts.AddHebrewDatesForEvents) && prevEventsLength != len(events)) {

--- a/molad/molad_test.go
+++ b/molad/molad_test.go
@@ -24,8 +24,11 @@ func TestMoladEvent_Render(t *testing.T) {
 	month := hdate.Iyyar
 	molad := molad.New(5783, month)
 	hd := hdate.New(5783, hdate.Nisan, 24)
-	ev := event.NewMoladEvent(hd, molad, month.String())
-	assert.Equal(t, "Molad Iyyar: Thu, 8 minutes and 13 chalakim after 14:00", ev.Render("en"))
+	ev := event.NewMoladEvent(hd, molad, month.String(), "US")
+	assert.Equal(t, "Molad Iyyar: Thursday, 2:08pm and 13 chalakim", ev.Render("en"))
 	assert.Equal(t, "מוֹלָד הָלְּבָנָה אִיָּיר יִהְיֶה בַּיּוֹם חֲמִישִׁי בשָׁבוּעַ, בְּשָׁעָה 14 בַּצׇּהֳרַיִים, ו-8 דַּקּוֹת ו-13 חֲלָקִים", ev.Render("he"))
 	assert.Equal(t, "מולד הלבנה אייר יהיה ביום חמישי בשבוע, בשעה 14 בצהריים, ו-8 דקות ו-13 חלקים", ev.Render("he-x-NoNikud"))
+	// A 24-hour country (e.g. IL) omits the am/pm suffix.
+	evIL := event.NewMoladEvent(hd, molad, month.String(), "IL")
+	assert.Equal(t, "Molad Iyyar: Thursday, 14:08 and 13 chalakim", evIL.Render("en"))
 }


### PR DESCRIPTION
Render the English molad announcement as
"Molad &lt;Month&gt;: &lt;FullWeekday&gt;, &lt;time&gt;[ and &lt;N&gt; chalakim]" to match @hebcal/core, replacing the old
"...: &lt;Thu&gt;, &lt;M&gt; minutes and &lt;N&gt; chalakim after &lt;H&gt;:00" form.

The wall-clock time is location dependent: 12-hour with an am/pm suffix in 12-hour countries (US, CA, ...) and 24-hour elsewhere, so NewMoladEvent now takes a country code. The molad calculation itself is location independent. Chalakim are omitted when zero in both the English and Hebrew renderings, matching core.
